### PR TITLE
Fix github workflow failing for contract tests

### DIFF
--- a/.github/workflows/test_contracts.yml
+++ b/.github/workflows/test_contracts.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Enable corepack
+        run: corepack enable
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "oracle.vechain.energy",
+  "packageManager": "yarn@3.6.1"
+}


### PR DESCRIPTION
GitHub workflows refused to work due missing package manager information in the root directory, even that work-directory was set to a sub-folder.