### PR TITLE
Add ability to manage multiple chains with one feed

### DIFF
--- a/reporter/README.md
+++ b/reporter/README.md
@@ -46,10 +46,12 @@ curl -XPOST http://localhost:8787/vet-usd \
     "heartbeat": 3600,
     "deviationPoints": 100,
     "interval": 60,
-    "contract": {
-        "nodeUrl": "https://node-testnet.vechain.energy",
-        "address": "<CONTRACT_ADDRESS>"
-    }
+    "contracts": [
+        {
+            "nodeUrl": "https://node-testnet.vechain.energy",
+            "address": "<CONTRACT_ADDRESS>"
+        }
+    ]
 }
 '
 ```

--- a/reporter/public/swagger.yml
+++ b/reporter/public/swagger.yml
@@ -212,14 +212,16 @@ components:
         interval:
           type: integer
           example: 60
-        contract:
-          type: object
-          properties:
-            nodeUrl:
-              type: string
-              example: "https://node-testnet.vechain.energy"
-            address:
-              type: string
+        contracts:
+          type: array
+          items:
+            type: object
+            properties:
+              nodeUrl:
+                type: string
+                example: "https://node-testnet.vechain.energy"
+              address:
+                type: string
     RequestCCIP:
      type: object
      properties:
@@ -252,6 +254,16 @@ components:
            healthy:
              type: boolean
              example: true
+           unhealthyContracts:
+             type: array
+             items:
+               type: object
+               properties:
+                 nodeUrl:
+                   type: string
+                   example: "https://node-testnet.vechain.energy"
+                 address:
+                   type: string
            nextUpdate:
               type: integer
               example: 60
@@ -268,6 +280,17 @@ components:
               interval:
                 type: integer
                 example: 60
+              contracts:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    nodeUrl:
+                      type: string
+                      example: "https://node-testnet.vechain.energy"
+                    address:
+                      type: string
+
            latestValue:
              type: object
              optional: true

--- a/reporter/src/ValueReporter.ts
+++ b/reporter/src/ValueReporter.ts
@@ -167,22 +167,25 @@ export class ValueReporter {
       const latestValue = await this.storage.get<Report>('latestValue')
       const nextUpdate = await this.storage.getAlarm()
 
-      const healthy = !latestValue?.value ? false : (await requiredUpdates(config, latestValue.value)).length === 0
+      const unhealthyContracts = latestValue?.value ? await requiredUpdates(config, latestValue.value) : []
+      const healthy = !latestValue?.value ? false : unhealthyContracts.length === 0
       const status = <Status>{
         id: config.id,
-        nextUpdate,
-        healthy,
         config: {
           interval: config.interval,
           heartbeat: config.heartbeat,
           deviationPoints: config.deviationPoints,
+          contracts: config.contracts
         },
         latestValue: latestValue
           ? {
             ...latestValue,
             formattedValue: ethers.formatUnits(latestValue.value, 12)
           }
-          : undefined
+          : undefined,
+        nextUpdate,
+        healthy,
+        unhealthyContracts
       }
 
       if (args?.report) {

--- a/reporter/src/ValueReporter.ts
+++ b/reporter/src/ValueReporter.ts
@@ -120,7 +120,7 @@ export class ValueReporter {
     const requiredContractUpdates = await requiredUpdates(config, data.value)
     for (const contract of requiredContractUpdates) {
       console.log(config.id, '**updating**')
-      const updatedDetails = await publishReport({ config, contract, report, env: this.env })
+      const updatedDetails = await publishReport({ contract, report, env: this.env })
       console.log(config.id, updatedDetails)
     }
   }
@@ -167,7 +167,7 @@ export class ValueReporter {
       const latestValue = await this.storage.get<Report>('latestValue')
       const nextUpdate = await this.storage.getAlarm()
 
-      const healthy = !latestValue?.value ? false : !await isUpdateRequired(config, latestValue.value)
+      const healthy = !latestValue?.value ? false : (await requiredUpdates(config, latestValue.value)).length === 0
       const status = <Status>{
         id: config.id,
         nextUpdate,

--- a/reporter/src/ValueReporter.ts
+++ b/reporter/src/ValueReporter.ts
@@ -2,7 +2,7 @@ import { type Env, type FeedConfig, type Report, type Status, CcipRequestSchema,
 import { z } from 'zod'
 import publishReport from './modules/publishReport';
 import fetchDataSources from './modules/fetchDataSources';
-import isUpdateRequired from './modules/isUpdateRequired'
+import requiredUpdates from './modules/requiredUpdates'
 import signCcipRequest from './modules/signCcipRequest';
 import { ethers } from 'ethers';
 
@@ -117,14 +117,11 @@ export class ValueReporter {
     console.log(config.id, 'last value:', report.value, 'updatedAt', report.updatedAt)
     console.log(config.id, 'calculation basics', data)
 
-    const shouldUpdate = await isUpdateRequired(config, data.value)
-    if (shouldUpdate) {
+    const requiredContractUpdates = await requiredUpdates(config, data.value)
+    for (const contract of requiredContractUpdates) {
       console.log(config.id, '**updating**')
-      const updatedDetails = await publishReport({ config, report, env: this.env })
+      const updatedDetails = await publishReport({ config, contract, report, env: this.env })
       console.log(config.id, updatedDetails)
-    }
-    else {
-      console.log(config.id, 'not updating')
     }
   }
 

--- a/reporter/src/modules/publishReport.test.ts
+++ b/reporter/src/modules/publishReport.test.ts
@@ -1,10 +1,10 @@
 import publishReport from './publishReport'
-import type { FeedConfig, Report } from '../types'
+import type { FeedConfig, FeedContract, Report } from '../types'
 import { ethers } from 'ethers'
 import { OracleV1 } from '../constants/Contract'
 
 
-describe('publishReport({ config, report, env })', () => {
+describe('publishReport({ contract, report, env })', () => {
 
     let fetchMock: any = undefined;
 
@@ -17,29 +17,29 @@ describe('publishReport({ config, report, env })', () => {
     });
 
     it('returns raw text result from transaction submission', async () => {
-        const task = getMockTask()
+        const contract = getMockContract()
         const report = getMockReport()
         const mockResponse = {
             text: jest.fn().mockResolvedValue('mocked response')
         }
         fetchMock.mockResolvedValue(mockResponse as any)
-        const result = await publishReport({ config: task, report })
+        const result = await publishReport({ contract, report })
         expect(fetchMock).toHaveBeenCalled()
         expect(result).toBe('mocked response')
     })
 
     it('submits the correct transaction call with updateValue(id, newValue, newTimestamp)', async () => {
-        const task = getMockTask()
+        const contract = getMockContract()
         const report = getMockReport()
 
         const clauses = [
             {
-                to: task.contract.address,
+                to: contract.address,
                 data: OracleV1.encodeFunctionData('updateValue', [ethers.encodeBytes32String(report.id), report.value, report.updatedAt])
             }
         ]
 
-        await publishReport({ config: task, report })
+        await publishReport({ contract, report })
         expect(fetchMock).toHaveBeenCalledWith(
             'https://api.vechain.energy/v1/transaction',
             {
@@ -56,22 +56,10 @@ describe('publishReport({ config, report, env })', () => {
     })
 })
 
-function getMockTask(values?: Partial<FeedConfig>): FeedConfig {
+function getMockContract(values?: Partial<FeedContract>): FeedContract {
     return {
-        id: 'vet-usd',
-        heartbeat: 86400,
-        deviationPoints: 100,
-        interval: 10,
-        contract: {
-            nodeUrl: 'https://',
-            address: '0x..'
-        },
-        sources: [
-            {
-                url: 'https://test.com',
-                path: ''
-            }
-        ],
+        nodeUrl: 'https://',
+        address: '0x..',
         ...values
     }
 }

--- a/reporter/src/modules/publishReport.ts
+++ b/reporter/src/modules/publishReport.ts
@@ -1,11 +1,11 @@
-import type { FeedConfig, Report, Env } from '../types'
+import type { FeedContract, Report, Env } from '../types'
 import { ethers } from 'ethers'
 import { OracleV1 } from '../constants/Contract'
 
-export default async function publishReport({ config, report, env }: { config: FeedConfig, report: Report, env?: Env }): Promise<string> {
+export default async function publishReport({ contract, report, env }: { contract: FeedContract, report: Report, env?: Env }): Promise<string> {
     const clauses = [
         {
-            to: config.contract.address,
+            to: contract.address,
             data: OracleV1.encodeFunctionData('updateValue', [ethers.encodeBytes32String(report.id), report.value, report.updatedAt])
         }
     ]

--- a/reporter/src/types.ts
+++ b/reporter/src/types.ts
@@ -1,14 +1,16 @@
 import { z } from 'zod'
 
+export const FeedContractSchema = z.object({
+  nodeUrl: z.string(),
+  address: z.string()
+})
+
 export const FeedConfigSchema = z.object({
   id: z.string(),
   heartbeat: z.number(),
   deviationPoints: z.number(),
   interval: z.number(),
-  contract: z.object({
-    nodeUrl: z.string(),
-    address: z.string()
-  }),
+  contracts: z.array(FeedContractSchema),
   sources: z.array(z.object({
     url: z.string(),
     path: z.string()
@@ -72,5 +74,6 @@ export interface Env {
 
 export type Report = z.infer<typeof ReportSchema>;
 export type FeedConfig = z.infer<typeof FeedConfigSchema>;
+export type FeedContract = z.infer<typeof FeedContractSchema>;
 export type Status = z.infer<typeof StatusSchema>;
 export type DataResult = z.infer<typeof DataSourceResultSchema>;

--- a/reporter/src/types.ts
+++ b/reporter/src/types.ts
@@ -48,16 +48,18 @@ export const DataSourceResultSchema = z.object({
 
 export const StatusSchema = z.object({
   healthy: z.boolean(),
+  unhealthyContracts: z.array(FeedContractSchema),
   nextUpdate: z.number().nullable(),
   config: z.object({
     interval: z.number(),
     heartbeat: z.number(),
-    deviationPoints: z.number()
+    deviationPoints: z.number(),
+    contracts: z.array(FeedContractSchema)
   }),
   dataSource: DataSourceResultSchema.optional(),
   latestValue: ReportSchema.extend({
     formattedValue: z.string(),
-  }).optional()
+  }).optional(),
 });
 
 export interface Env {

--- a/reporter/src/types.ts
+++ b/reporter/src/types.ts
@@ -54,12 +54,7 @@ export const StatusSchema = z.object({
     heartbeat: z.number(),
     deviationPoints: z.number()
   }),
-  sources: z.array(z.object({
-    url: z.string(),
-    path: z.string(),
-    value: z.number(),
-    available: z.boolean()
-  })).optional(),
+  dataSource: DataSourceResultSchema.optional(),
   latestValue: ReportSchema.extend({
     formattedValue: z.string(),
   }).optional()


### PR DESCRIPTION
A single configuration can now manage multiple contracts on different nodes.

Example use case is VET/USD been synchronized to TestNet and MainNet from the same data source.