### PR TITLE
Extend sources with http headers & hex parsing

### DIFF
--- a/reporter/src/types.ts
+++ b/reporter/src/types.ts
@@ -13,8 +13,12 @@ export const FeedConfigSchema = z.object({
   contracts: z.array(FeedContractSchema),
   sources: z.array(z.object({
     url: z.string(),
-    path: z.string()
-  })).min(1),
+    path: z.string(),
+    method: z.enum(['POST', 'GET']).optional(),
+    body: z.string().optional(),
+    headers: z.record(z.string()).optional(),
+    decimals: z.number().default(18).optional()
+})).min(1),
 });
 
 export const ReportSchema = z.object({

--- a/statuspage/src/Feed/Status.tsx
+++ b/statuspage/src/Feed/Status.tsx
@@ -7,13 +7,17 @@ import FeedSheet from './Sheet';
 
 const UPDATE_INTERVAL_SECONDS = 30
 export default function FeedStatus({ feedId }: { feedId: string }): React.ReactElement {
-    const { data, isLoading } = useQuery<Status>({
+    const { data, isLoading } = useQuery<Status | { message: string }>({
         queryKey: [feedId],
-        queryFn: ({ queryKey }) => fetch(`${ORACLE_API_URL}/${feedId}`).then((res) => res.json()),
+        queryFn: () => fetch(`${ORACLE_API_URL}/${feedId}`).then((res) => res.json()),
         enabled: true,
         keepPreviousData: true,
         refetchInterval: UPDATE_INTERVAL_SECONDS * 1000
     })
+
+    if (data && 'message' in data) {
+        return <div className="text-red-600 font-bold">{feedId}: {data.message}</div>
+    }
 
     return (
         <div className="rounded overflow-hidden shadow-lg p-4">


### PR DESCRIPTION
Extend data source loading from GET to POST Requests, including body. Additional provides the ability to define headers for data source requests.

To support loading from other chain contracts, hex parsing and formatting with ethers is supported too.