### PR TITLE
Add value contract aggregator

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -17,9 +17,11 @@ interface IVechainEnergyOracleV1 {
 }
 ```
 
-* `id` is a byte32 encoded version of the feed identifier (for example `vet-usd`)
-* `value` is the value provided by the oracle
-* `updatedAt` is the unix timestamp when the value was last determined
+- `id` is a byte32 encoded version of the feed identifier (for example `vet-usd`)
+- `value` is the value provided by the oracle
+- `updatedAt` is the unix timestamp when the value was last determined
+
+To support a decentralized approach, an aggregator contract `OracleAggregatorUpgradeable` can be deployed and load values from multiple configurable sources. The median value of all sources is calculated and return within the contract.
 
 ## Contract Details
 
@@ -62,8 +64,7 @@ PRIVATE_KEY="0x…" NETWORK=main yarn deploy OracleGasOptimized
 
 After deployment, the ABI and Addresses are archived in the `outputs/` folder.
 
-
-####  Oracle Upgradeable
+#### Oracle Upgradeable
 
 This contract is designed to be upgradable and uses roles for access control.
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -21,7 +21,7 @@ interface IVechainEnergyOracleV1 {
 - `value` is the value provided by the oracle
 - `updatedAt` is the unix timestamp when the value was last determined
 
-To support a decentralized approach, an aggregator contract `OracleAggregatorUpgradeable` can be deployed and load values from multiple configurable sources. The median value of all sources is calculated and return within the contract.
+To support a decentralized approach, an aggregator contract `OracleAggregatorUpgradeable` can be deployed and load values from multiple configurable sources. The median value of all sources is calculated and returned by the contract.
 
 ## Contract Details
 
@@ -48,9 +48,9 @@ yarn install
 yarn test
 ```
 
-### Deployment Instructions
+## Deployment Instructions
 
-#### Oracle Gas Optimized
+### Oracle Gas Optimized
 
 This contract is gas optimized and can only have one reporter.
 
@@ -64,7 +64,7 @@ PRIVATE_KEY="0x…" NETWORK=main yarn deploy OracleGasOptimized
 
 After deployment, the ABI and Addresses are archived in the `outputs/` folder.
 
-#### Oracle Upgradeable
+### Oracle Upgradeable
 
 This contract is designed to be upgradable and uses roles for access control.
 
@@ -108,7 +108,7 @@ After deployment, the ABI and Addresses are archived in the `outputs/` folder.
 PRIVATE_KEY="0x…" NETWORK=vechain yarn deploy:upgrade OracleUpgradable
 ```
 
-#### Oracle Aggregator
+### Oracle Aggregator
 
 This contract collects data from various Oracle-Contracts and provides the median from their latest data. Each contract must be added using `addSource`.
 
@@ -118,6 +118,13 @@ The contract can be upgraded and controlled by the `ADMIN_ROLE` using the follow
 2. `removeSource(address sourceAddress)` - Removes an existing data source.
 3. `isSource(address sourceAddress) returns (bool)` - Checks if a given address is a data source.
 4. `sources() returns (addresses[])` - Returns a list of all data sources.
+5. `setIgnoreUpdatesOlderThan(seconds)` - Sets a maximum age for data sources.
+6. `ignoreUpdatesOlderThan` - All reports must be updated within the time frame defined by this variable.
+
+**Automatically Filter Inactive Sources**
+
+- If `setIgnoreUpdatesOlderThan(seconds)` is not set or `0`, all values will be aggregated.
+- If set, reports older than `seconds` will be ignored.
 
 **Initial Deployment**
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -90,6 +90,8 @@ function updateValue(bytes32 id, uint256 newValue, uint64 newTimestamp)
 function getLatestValue(bytes32 id) public view returns (uint256 value, uint64 updatedAt)
 ```
 
+**Initial Deployment**
+
 ```shell
 # For TestNet
 PRIVATE_KEY="0x…" NETWORK=vechain yarn deploy:proxy OracleUpgradable
@@ -104,4 +106,33 @@ After deployment, the ABI and Addresses are archived in the `outputs/` folder.
 
 ```shell
 PRIVATE_KEY="0x…" NETWORK=vechain yarn deploy:upgrade OracleUpgradable
+```
+
+#### Oracle Aggregator
+
+This contract collects data from various Oracle-Contracts and provides the median from their latest data. Each contract must be added using `addSource`.
+
+The contract can be upgraded and controlled by the `ADMIN_ROLE` using the following functions:
+
+1. `addSource(address sourceAddress)` - Adds a new data source.
+2. `removeSource(address sourceAddress)` - Removes an existing data source.
+3. `isSource(address sourceAddress) returns (bool)` - Checks if a given address is a data source.
+4. `sources() returns (addresses[])` - Returns a list of all data sources.
+
+**Initial Deployment**
+
+```shell
+# For TestNet
+PRIVATE_KEY="0x…" NETWORK=vechain yarn deploy:proxy OracleAggregatorUpgradable
+
+# For MainNet
+PRIVATE_KEY="0x…" NETWORK=main yarn deploy:proxy OracleAggregatorUpgradable
+```
+
+After deployment, the ABI and Addresses are archived in the `outputs/` folder.
+
+**Upgrades**
+
+```shell
+PRIVATE_KEY="0x…" NETWORK=vechain yarn deploy:upgrade OracleAggregatorUpgradable
 ```

--- a/contracts/contracts/OracleAggregatorUpgradable.sol
+++ b/contracts/contracts/OracleAggregatorUpgradable.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/structs/EnumerableSetUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "./utils/SignatureVerifier.sol";
+import "./IVechainEnergyOracleV1.sol";
+
+/**
+ * @title OracleUpgradable
+ * @dev This contract is used to manage and update oracle values
+ */
+contract OracleAggregatorUpgradable is
+    Initializable,
+    UUPSUpgradeable,
+    AccessControlUpgradeable
+{
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
+
+    /**
+     * @dev Struct to hold the feed value
+     */
+    struct Report {
+        uint128 value;
+        uint128 updatedAt;
+    }
+
+    /**
+     * @dev The list of data sources
+     */
+    using EnumerableSetUpgradeable for EnumerableSetUpgradeable.AddressSet;
+    EnumerableSetUpgradeable.AddressSet private _sources;
+
+    /**
+     * @dev Constructor to disable initializers
+     */
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @dev Function to initialize the contract
+     */
+    function initialize() public initializer {
+        __UUPSUpgradeable_init();
+
+        _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _setupRole(UPGRADER_ROLE, msg.sender);
+        _setupRole(ADMIN_ROLE, msg.sender);
+    }
+
+    /**
+     * @dev Function to add a new oracle source. Restricted to ADMIN_ROLE.
+     * @param sourceAddress The address for the contract to add
+     */
+    function addSource(address sourceAddress) public onlyRole(ADMIN_ROLE) {
+        _sources.add(sourceAddress);
+    }
+
+    /**
+     * @dev Function to remove an existing oracle source. Restricted to ADMIN_ROLE.
+     * @param sourceAddress The address for the contract to remove
+     */
+    function removeSource(address sourceAddress) public onlyRole(ADMIN_ROLE) {
+        _sources.remove(sourceAddress);
+    }
+
+    /**
+     * @dev Function to get information if an address is a valid oracle source.
+     * @param sourceAddress The address for the contract to test
+     */
+    function isSource(address sourceAddress) public view returns (bool) {
+        return _sources.contains(sourceAddress);
+    }
+
+    /**
+     * @dev Function to get a list of all oracle sources.
+     * @return oracleSources An array of addresses representing all oracle sources
+     */
+    function sources() public view returns (address[] memory oracleSources) {
+        oracleSources = _sources.values();
+    }
+
+    /**
+     * @dev Function to get the median value for a given id.
+     * @param id The id to retrieve the value for
+     * @return value The latest value
+     */
+    function getLatestValue(
+        bytes32 id
+    ) public view returns (uint128 value, uint128 updatedAt) {
+        Report memory median = medianPrice(id, _sources.values());
+        return (median.value, median.updatedAt);
+    }
+
+    /**
+     * @notice Calculates the median price over any set of sources. Has been adopted from https://github.com/compound-finance/open-oracle/blob/e7a928334e5e454a88eec38e4ee1be5ee3b13f08/contracts/DelFiPrice.sol#L86-L106
+     * @param id The id to calculate the median price of
+     * @param sources_ The sources to use when calculating the median price
+     * @return median The median price over the set of sources
+     */
+    function medianPrice(
+        bytes32 id,
+        address[] memory sources_
+    ) public view returns (Report memory median) {
+        require(sources_.length > 0, "sources list must not be empty");
+
+        uint N = sources_.length;
+        Report[] memory postedPrices = new Report[](N);
+        for (uint i = 0; i < N; i++) {
+            (
+                postedPrices[i].value,
+                postedPrices[i].updatedAt
+            ) = IVechainEnergyOracleV1(sources_[i]).getLatestValue(id);
+        }
+
+        Report[] memory sortedPrices = sort(postedPrices);
+
+        // if N is even, get the left and right medians and average them
+        // return the newest timestamp of the both
+        if (N % 2 == 0) {
+            Report memory left = sortedPrices[(N / 2) - 1];
+            Report memory right = sortedPrices[N / 2];
+
+            uint128 sum = left.value + right.value;
+            uint128 updatedAt = left.updatedAt > right.updatedAt
+                ? left.updatedAt
+                : right.updatedAt;
+            return Report(uint128(sum / 2), updatedAt);
+        } else {
+            // if N is odd, just return the median
+            return sortedPrices[N / 2];
+        }
+    }
+
+    /**
+     * @notice Helper to sort an array of uints
+     * @param array Array of integers to sort
+     * @return The sorted array of integers
+     */
+    function sort(
+        Report[] memory array
+    ) private pure returns (Report[] memory) {
+        uint N = array.length;
+        for (uint i = 0; i < N; i++) {
+            for (uint j = i + 1; j < N; j++) {
+                if (array[i].value > array[j].value) {
+                    Report memory tmp = array[i];
+                    array[i] = array[j];
+                    array[j] = tmp;
+                }
+            }
+        }
+        return array;
+    }
+
+    /**
+     * @dev Function to authorize an upgrade. Restricted to UPGRADER_ROLE.
+     * @param newImplementation The address of the new implementation
+     */
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal override onlyRole(UPGRADER_ROLE) {}
+}

--- a/contracts/contracts/OracleAggregatorUpgradable.test.js
+++ b/contracts/contracts/OracleAggregatorUpgradable.test.js
@@ -1,0 +1,202 @@
+const { ethers } = require('hardhat')
+const Web3EthAbi = require('web3-eth-abi')
+const ERC1967Proxy = require('@openzeppelin/contracts/build/contracts/ERC1967Proxy.json')
+
+async function bootSystem() {
+    const [owner, upgrader, anon, admin, reporter, user1, user2, user3] = await ethers.getSigners()
+    const users = { owner, admin, upgrader, anon, reporter, user1, user2, user3 }
+
+    const OracleGasOptimized = await ethers.getContractFactory("OracleGasOptimized")
+    const contracts = {
+        aggregator: await getContractWithProxy('OracleAggregatorUpgradable'),
+        oracleV1: await getContractWithProxy('OracleUpgradable'),
+        oracleV2: await OracleGasOptimized.deploy()
+    }
+
+    await contracts.oracleV2.updateReporter(reporter.address)
+
+    await grantUserRole(users.upgrader.address, 'UPGRADER_ROLE')
+    await grantUserRole(users.reporter.address, 'REPORTER_ROLE')
+
+    const adminRoleId = await contracts.aggregator.ADMIN_ROLE()
+    await contracts.aggregator.grantRole(adminRoleId, users.admin.address)
+
+    return { contracts, users }
+
+    async function grantUserRole(address, roleName) {
+        const roleId = await contracts.oracleV1[roleName]()
+        await contracts.oracleV1.grantRole(roleId, address)
+    }
+}
+
+describe('Aggregator', () => {
+    describe('addSource(address)', () => {
+        it('rejects non-admin calls', async () => {
+            const { contracts, users } = await bootSystem()
+            await expect(contracts.aggregator.connect(users.anon).addSource(contracts.oracleV1.address)).rejects.toThrow()
+        })
+
+        it('adds a new feed source', async () => {
+            const { contracts, users } = await bootSystem()
+
+            await contracts.aggregator.connect(users.admin).addSource(contracts.oracleV1.address)
+            const result = await contracts.aggregator.isSource(contracts.oracleV1.address)
+
+            await expect(result).toEqual(true)
+        })
+
+        it('supports multiple new new feed sources', async () => {
+            const { contracts, users } = await bootSystem()
+
+            await contracts.aggregator.connect(users.admin).addSource(contracts.oracleV1.address)
+            expect(await contracts.aggregator.isSource(contracts.oracleV1.address)).toEqual(true)
+
+            await contracts.aggregator.connect(users.admin).addSource(contracts.oracleV2.address)
+            expect(await contracts.aggregator.isSource(contracts.oracleV2.address)).toEqual(true)
+        })
+    })
+
+    describe('removeSource(address)', () => {
+        it('rejects non-admin calls', async () => {
+            const { contracts, users } = await bootSystem()
+            await expect(contracts.aggregator.connect(users.anon).removeSource(contracts.oracleV1.address)).rejects.toThrow()
+        })
+
+        it('removes a feed source', async () => {
+            const tokenData = [ethers.utils.formatBytes32String("test"), BigInt(1), BigInt(3)]
+            const { contracts, users } = await bootSystem()
+
+            await contracts.aggregator.connect(users.admin).addSource(contracts.oracleV1.address)
+            await contracts.aggregator.connect(users.admin).removeSource(contracts.oracleV1.address)
+            const result = await contracts.aggregator.isSource(contracts.oracleV1.address)
+
+            await expect(result).toEqual(false)
+        })
+
+    })
+
+    describe('isSource(address)', () => {
+        it('returns false by default', async () => {
+            const { contracts } = await bootSystem()
+            expect(await contracts.aggregator.isSource(contracts.oracleV1.address)).toEqual(false)
+        })
+
+        it('returns true for added sources', async () => {
+            const { contracts, users } = await bootSystem()
+            await contracts.aggregator.connect(users.admin).addSource(contracts.oracleV1.address)
+            expect(await contracts.aggregator.isSource(contracts.oracleV1.address)).toEqual(true)
+        })
+
+        it('returns false for removed sources', async () => {
+            const { contracts, users } = await bootSystem()
+            await contracts.aggregator.connect(users.admin).addSource(contracts.oracleV1.address)
+            await contracts.aggregator.connect(users.admin).removeSource(contracts.oracleV1.address)
+            expect(await contracts.aggregator.isSource(contracts.oracleV1.address)).toEqual(false)
+        })
+    })
+
+    describe('sources()', () => {
+        it('returns the list of sources', async () => {
+            const { contracts, users } = await bootSystem()
+            await contracts.aggregator.connect(users.admin).addSource(contracts.oracleV1.address)
+            await contracts.aggregator.connect(users.admin).addSource(contracts.oracleV2.address)
+
+            expect(await contracts.aggregator.sources()).toEqual([contracts.oracleV1.address, contracts.oracleV2.address])
+        })
+    })
+
+    describe('getLatestValue(id)', () => {
+        it('returns (value, updatedAt)', async () => {
+            const tokenData = [ethers.utils.formatBytes32String("test"), BigInt(1), BigInt(3)]
+            const { contracts, users } = await bootSystem()
+
+            await contracts.oracleV1.connect(users.reporter).updateValue(...tokenData)
+            await contracts.aggregator.addSource(contracts.oracleV1.address)
+            const result = await contracts.aggregator.getLatestValue(tokenData[0])
+
+            await expect(Number(result[0])).toEqual(Number(tokenData[1]))
+            await expect(Number(result[1])).toEqual(Number(tokenData[2]))
+        })
+
+        it('returns the average for even list of multiple sources', async () => {
+            const id = ethers.utils.formatBytes32String("test")
+            const tokenData1 = [id, BigInt(2), BigInt(3)]
+            const tokenData2 = [id, BigInt(4), BigInt(3)]
+
+            const { contracts, users } = await bootSystem()
+
+            await contracts.oracleV1.connect(users.reporter).updateValue(...tokenData1)
+            await contracts.aggregator.addSource(contracts.oracleV1.address)
+
+            await contracts.oracleV2.connect(users.reporter).updateValue(...tokenData2)
+            await contracts.aggregator.addSource(contracts.oracleV2.address)
+
+            const result = await contracts.aggregator.getLatestValue(id)
+            await expect(Number(result[0])).toEqual(Number(tokenData1[1] + tokenData2[1]) / 2)
+        })
+
+        it('returns newest timestamp for even list of multiple sources', async () => {
+            const id = ethers.utils.formatBytes32String("test")
+            const tokenData1 = [id, BigInt(2), BigInt(4)]
+            const tokenData2 = [id, BigInt(4), BigInt(3)]
+
+            const { contracts, users } = await bootSystem()
+
+            await contracts.oracleV1.connect(users.reporter).updateValue(...tokenData1)
+            await contracts.aggregator.addSource(contracts.oracleV1.address)
+
+            await contracts.oracleV2.connect(users.reporter).updateValue(...tokenData2)
+            await contracts.aggregator.addSource(contracts.oracleV2.address)
+
+            const result = await contracts.aggregator.getLatestValue(id)
+            await expect(Number(result[1])).toEqual(Number(tokenData1[2]))
+        })
+
+        it('returns the median for odd list of multiple sources', async () => {
+            const id = ethers.utils.formatBytes32String("test")
+            const tokenData1 = [id, BigInt(2), BigInt(3)]
+            const tokenData2 = [id, BigInt(4), BigInt(3)]
+            const tokenData3 = [id, BigInt(6), BigInt(3)]
+
+            const { contracts, users } = await bootSystem()
+
+            await contracts.oracleV1.connect(users.reporter).updateValue(...tokenData1)
+            await contracts.aggregator.addSource(contracts.oracleV1.address)
+
+            await contracts.oracleV2.connect(users.reporter).updateValue(...tokenData2)
+            await contracts.aggregator.addSource(contracts.oracleV2.address)
+
+            const Oracle3 = await ethers.getContractFactory("OracleGasOptimized")
+            const oracle3 = await Oracle3.deploy()
+            await oracle3.updateReporter(users.reporter.address)
+            await oracle3.connect(users.reporter).updateValue(...tokenData3)
+            await contracts.aggregator.addSource(oracle3.address)
+
+            const result = await contracts.aggregator.getLatestValue(id)
+            await expect(Number(result[0])).toEqual(Number(tokenData2[1]))
+            await expect(Number(result[1])).toEqual(Number(tokenData2[2]))
+        })
+    })
+})
+
+
+
+async function getContractWithProxy(contractName) {
+    // get contract details
+    const Contract = await ethers.getContractFactory(contractName)
+    const contract = await Contract.deploy()
+
+    const Proxy = await ethers.getContractFactoryFromArtifact(ERC1967Proxy)
+
+    // calculate initialize() call during deployment
+    const initializeAbi = Contract.interface.fragments.find(({ name }) => name === 'initialize')
+    const callInitialize = Web3EthAbi.encodeFunctionCall(initializeAbi, [])
+
+    // deploy proxy pointing to contract
+    const proxy = await Proxy.deploy(contract.address, callInitialize)
+
+    // return proxy address attached with contract functionality
+    const proxiedContract = Contract.attach(proxy.address)
+    return proxiedContract
+}
+

--- a/contracts/contracts/OracleUpgradable.sol
+++ b/contracts/contracts/OracleUpgradable.sol
@@ -5,7 +5,6 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol";
 import "./utils/SignatureVerifier.sol";
-import "hardhat/console.sol";
 
 /**
  * @title OracleUpgradable
@@ -152,11 +151,9 @@ contract OracleUpgradable is
      */
     function _selectRandomReporter() internal {
         uint reporterCount = getRoleMemberCount(REPORTER_ROLE);
-        uint256 newReporterIndex =
-            uint256(
-                keccak256(abi.encodePacked(block.timestamp, block.prevrandao))
-            ) %
-            reporterCount;
+        uint256 newReporterIndex = uint256(
+            keccak256(abi.encodePacked(block.timestamp, block.prevrandao))
+        ) % reporterCount;
         // Ensure the index is changed, if the new calculated index is the same as before, increment and ensure bounds are kept
         if (newReporterIndex == _selectedNextReporter) {
             newReporterIndex = (newReporterIndex + 1) % reporterCount;


### PR DESCRIPTION
This PR adds a new contract that can source its value from different deployed oracle contracts.

Sources can be managed within the contract and the median value is extracted from the all configured contracts. For transparency the list of sources is always available.